### PR TITLE
Set colors to a safe version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.7.2",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "core-js": "^3.14.0",
     "redis": "^3.1.2",
     "redis-splitargs": "^1.0.1",


### PR DESCRIPTION
Explicitly set colors to a safe version to address the LIBERTY LIBERTY LIBERTY challenge.

Potential fix for:  
https://github.com/lujiajing1126/redis-cli/issues/39